### PR TITLE
Make search case insensitive

### DIFF
--- a/pass.cpp
+++ b/pass.cpp
@@ -103,7 +103,7 @@ void Pass::match(Plasma::RunnerContext &context)
 
     lock.lockForRead();
     Q_FOREACH (auto password, passwords) {
-        QRegularExpression re(".*" + input + ".*");
+        QRegularExpression re(".*" + input + ".*", QRegularExpression::CaseInsensitiveOption);
         if (re.match(password).hasMatch()) {
             Plasma::QueryMatch match(this);
             if (input.length() == password.length()) {


### PR DESCRIPTION
This makes the regex match case insensitive so one doesn't need to know the exact case when searching for their passwords.