### PR TITLE
Added support for pass-otp

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ Krunner pass
 
 Integrates [krunner](https://userbase.kde.org/Plasma/Krunner) with [pass](https://www.passwordstore.org).
 
+## Use with [pass-otp](https://github.com/tadfisher/pass-otp)
+
+To use with pass-otp, use the identifier "totp::" in the filename or file path of the otp password file.
+
+Alternatively, set $PASSWORD_STORE_OTP_IDENTIFIER to overwrite the identifier string.
+
 Build and Installation
 ======================
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Integrates [krunner](https://userbase.kde.org/Plasma/Krunner) with [pass](https:
 
 ## Use with [pass-otp](https://github.com/tadfisher/pass-otp)
 
-To use with pass-otp, use the identifier "totp::" in the filename or file path of the otp password file.
+To use with pass-otp, use the identifier "totp::" as a prefix in the filename or file path of the otp password file.
 
-Alternatively, set $PASSWORD_STORE_OTP_IDENTIFIER to overwrite the identifier string.
+Alternatively, set $PASSWORD_STORE_OTP_IDENTIFIER to overwrite the identifier string. This must be set in `.xprofile`
+or similar file.
 
 Build and Installation
 ======================

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Integrates [krunner](https://userbase.kde.org/Plasma/Krunner) with [pass](https:
 To use with pass-otp, use the identifier "totp::" as a prefix in the filename or file path of the otp password file.
 
 Alternatively, set $PASSWORD_STORE_OTP_IDENTIFIER to overwrite the identifier string. This must be set in `.xprofile`
-or similar file.
+or similar file, before the initalization of krunner.
 
 Build and Installation
 ======================

--- a/pass.cpp
+++ b/pass.cpp
@@ -125,7 +125,13 @@ void Pass::run(const Plasma::RunnerContext &context, const Plasma::QueryMatch &m
 {
     Q_UNUSED(context);
 
-    auto ret = match.text().contains("totp-", Qt::CaseInsensitive) ?
+    this->passOtpIdentifier = "totp::";
+    auto passOtpIdentifier = getenv("PASSWORD_STORE_OTP_IDENTIFIER");
+    if (passOtpIdentifier != nullptr) {
+        this->passOtpIdentifier = passOtpIdentifier;
+    }
+
+    auto ret = match.text().contains(this->passOtpIdentifier, Qt::CaseInsensitive) ?
         QProcess::execute(QString("pass otp -c ") + match.text()) :
         QProcess::execute(QString("pass -c ") + match.text());
     if (ret == 0) {

--- a/pass.cpp
+++ b/pass.cpp
@@ -125,7 +125,9 @@ void Pass::run(const Plasma::RunnerContext &context, const Plasma::QueryMatch &m
 {
     Q_UNUSED(context);
 
-    auto ret = QProcess::execute(QString("pass -c ") + match.text());
+    auto ret = match.text().contains("totp-", Qt::CaseInsensitive) ?
+        QProcess::execute(QString("pass otp -c ") + match.text()) :
+        QProcess::execute(QString("pass -c ") + match.text());
     if (ret == 0) {
         QString msg = i18n("Password %1 copied to clipboard for %2 seconds", match.text(), timeout);
         KNotification::event("password-unlocked", "Pass", msg,

--- a/pass.cpp
+++ b/pass.cpp
@@ -130,8 +130,9 @@ void Pass::run(const Plasma::RunnerContext &context, const Plasma::QueryMatch &m
     if (passOtpIdentifier != nullptr) {
         this->passOtpIdentifier = passOtpIdentifier;
     }
+    auto isOtp = match.text().split('/').filter(QRegularExpression("^" + QRegularExpression::escape(this->passOtpIdentifier) + ".*")).size() > 0;
 
-    auto ret = match.text().contains(this->passOtpIdentifier, Qt::CaseInsensitive) ?
+    auto ret = isOtp ?
         QProcess::execute(QString("pass otp -c ") + match.text()) :
         QProcess::execute(QString("pass -c ") + match.text());
     if (ret == 0) {

--- a/pass.cpp
+++ b/pass.cpp
@@ -131,7 +131,8 @@ void Pass::run(const Plasma::RunnerContext &context, const Plasma::QueryMatch &m
 {
     Q_UNUSED(context);
 
-    auto isOtp = match.text().split('/').filter(QRegularExpression("^" + QRegularExpression::escape(this->passOtpIdentifier) + ".*")).size() > 0;
+    auto regexp = QRegularExpression("^" + QRegularExpression::escape(this->passOtpIdentifier) + ".*");
+    auto isOtp = match.text().split('/').filter(regexp).size() > 0;
 
     auto ret = isOtp ?
         QProcess::execute(QString("pass otp -c ") + match.text()) :

--- a/pass.cpp
+++ b/pass.cpp
@@ -61,6 +61,12 @@ void Pass::init() {
         }
     }
 
+    this->passOtpIdentifier = "totp::";
+    auto passOtpIdentifier = getenv("PASSWORD_STORE_OTP_IDENTIFIER");
+    if (passOtpIdentifier != nullptr) {
+        this->passOtpIdentifier = passOtpIdentifier;
+    }
+
     initPasswords();
 
     connect(&watcher, SIGNAL(directoryChanged(QString)), this, SLOT(reinitPasswords(QString)));
@@ -125,11 +131,6 @@ void Pass::run(const Plasma::RunnerContext &context, const Plasma::QueryMatch &m
 {
     Q_UNUSED(context);
 
-    this->passOtpIdentifier = "totp::";
-    auto passOtpIdentifier = getenv("PASSWORD_STORE_OTP_IDENTIFIER");
-    if (passOtpIdentifier != nullptr) {
-        this->passOtpIdentifier = passOtpIdentifier;
-    }
     auto isOtp = match.text().split('/').filter(QRegularExpression("^" + QRegularExpression::escape(this->passOtpIdentifier) + ".*")).size() > 0;
 
     auto ret = isOtp ?

--- a/pass.h
+++ b/pass.h
@@ -44,6 +44,7 @@ protected:
 
 private:
     QDir baseDir;
+    QString passOtpIdentifier;
     int timeout;
     QReadWriteLock lock;
     QList<QString> passwords;


### PR DESCRIPTION
Convention: otp passwords must have the string "totp-" either in
the filename or the file path.

If the convention is followed, "pass otp" is called instead of
"pass", so that the totp token is copied to clipboard rather
than the raw otpauth:// URI.