### PR TITLE
Fix copy issue on password files with spaces

### DIFF
--- a/pass.cpp
+++ b/pass.cpp
@@ -136,8 +136,8 @@ void Pass::run(const Plasma::RunnerContext &context, const Plasma::QueryMatch &m
     auto isOtp = match.text().split('/').filter(regexp).size() > 0;
 
     auto ret = isOtp ?
-        QProcess::execute(QString("pass otp -c ") + match.text()) :
-        QProcess::execute(QString("pass -c ") + match.text());
+            QProcess::execute(QString("pass"), QStringList() << "otp" << "-c" << match.text()) :
+            QProcess::execute(QString("pass"), QStringList() << "-c" << match.text());
     if (ret == 0) {
         QString msg = i18n("Password %1 copied to clipboard for %2 seconds", match.text(), timeout);
         auto notification = KNotification::event("password-unlocked", "Pass", msg,


### PR DESCRIPTION
First of all, thanks for this extension. It really helped me.

This commit does two things. It fixes an error which happens because of non standard file names. For example, I have a password file named `GMail <isamertgurbuz@gmail.com>`. When I tried to copy this password, it failed. Probably the blank char caused this, because the file name is not quoted while calling `pass`. So I just wrapped the arguments into an argument list.

Secondly, it adds a feature to show full content of the password file. Because sometimes I need more information than just the password and when you get used to this plugin, it becomes hard to use command-line tool. So I think it can be handy to have this feature. It just creates a temp file and writes contents of the output of `pass` to the temp file. After that, it opens the temp file with `KWrite`. In KWrite's documentation, it says that `--tempfile` option must delete the opened files after use. But in my case, it didn't delete the files. So I added `rm $TEMP_FILE` as a fallback.