### PR TITLE
Fix krunner-pass not copying to clippboard on wayland and prevent Klipper from saving the password

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ find_package (KF5 ${KF5_MIN_VERSION}
   Notifications
   Auth
   KCMUtils
+  GuiAddons
 )
-
 include(KDEInstallDirs)
 include(KDECMakeSettings)
 include(KDECompilerSettings NO_POLICY_SCOPE)
@@ -73,7 +73,8 @@ target_link_libraries(krunner_pass KF5::Runner Qt5::Widgets
                       KF5::Service
                       KF5::Plasma
                       KF5::ConfigWidgets
-                      KF5::Notifications)
+                      KF5::Notifications
+                      KF5::GuiAddons)
 
 add_dependencies(krunner_pass kcm_krunner_pass)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,24 @@ set (CMAKE_MODULE_PATH
      ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR} ${CMAKE_MODULE_PATH}
 )
 
-find_package (Qt5 ${QT_MIN_VERSION} REQUIRED CONFIG COMPONENTS Widgets Core Quick DBus)
-find_package (KF5 ${KF5_MIN_VERSION} REQUIRED COMPONENTS I18n Service Runner TextWidgets ConfigWidgets PlasmaQuick Notifications Auth)
+find_package (Qt5 ${QT_MIN_VERSION}
+  REQUIRED CONFIG COMPONENTS
+  Widgets
+  Core
+  Quick
+  DBus
+)
+find_package (KF5 ${KF5_MIN_VERSION}
+  REQUIRED COMPONENTS
+  I18n
+  Service
+  Runner
+  TextWidgets
+  ConfigWidgets
+  PlasmaQuick
+  Notifications
+  Auth
+)
 
 include(KDEInstallDirs)
 include(KDECMakeSettings)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package (KF5 ${KF5_MIN_VERSION}
   PlasmaQuick
   Notifications
   Auth
+  KCMUtils
 )
 
 include(KDEInstallDirs)
@@ -63,6 +64,7 @@ target_link_libraries(kcm_krunner_pass
     KF5::I18n
     KF5::ConfigWidgets
     KF5::Runner
+    KF5::KCMUtils
     )
 
 add_library(krunner_pass MODULE ${krunner_pass_SRCS})

--- a/pass.cpp
+++ b/pass.cpp
@@ -26,6 +26,8 @@
 #include <QTimer>
 #include <QMessageBox>
 #include <QClipboard>
+#include <KSystemClipboard>
+#include <QMimeData>
 #include <QDebug>
 #include <QApplication>
 
@@ -185,10 +187,14 @@ void Pass::match(Plasma::RunnerContext &context)
 
 void Pass::clip(const QString &msg)
 {
-    QClipboard *cb = QApplication::clipboard();
-    cb->setText(msg);
-    QTimer::singleShot(timeout * 1000, cb, [cb]() {
-        cb->setText(QString());
+    auto md = new QMimeData;
+    auto kc = KSystemClipboard::instance();
+    // https://phabricator.kde.org/D12539
+    md->setText(msg);
+    md->setData(QStringLiteral("x-kde-passwordManagerHint"), "secret");
+    kc->setMimeData(md,QClipboard::Clipboard);
+    QTimer::singleShot(timeout * 1000, kc, [kc]() {
+        kc->clear(QClipboard::Clipboard);
     });
 }
 


### PR DESCRIPTION
Hi,

this commit fixes issues on wayland where krunner-pass would not copy the password to the clipboard and adds a special mimetype to the data in the clipboard so that Klipper (clipboard manager for KDE) will not save the plaintext password in the history.