### PR TITLE
Add Wayland support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set (CMAKE_MODULE_PATH
 )
 
 find_package (Qt5 ${QT_MIN_VERSION} REQUIRED CONFIG COMPONENTS Widgets Core Quick DBus)
-find_package (KF5 ${KF5_MIN_VERSION} REQUIRED COMPONENTS I18n Service Runner TextWidgets ConfigWidgets PlasmaQuick Notifications Auth)
+find_package (KF5 ${KF5_MIN_VERSION} REQUIRED COMPONENTS I18n Service Runner TextWidgets ConfigWidgets PlasmaQuick Notifications Auth GuiAddons)
 
 include(KDEInstallDirs)
 include(KDECMakeSettings)
@@ -55,7 +55,8 @@ target_link_libraries(krunner_pass KF5::Runner Qt5::Widgets
                       KF5::Service
                       KF5::Plasma
                       KF5::ConfigWidgets
-                      KF5::Notifications)
+                      KF5::Notifications
+                      KF5::GuiAddons)
 
 add_dependencies(krunner_pass kcm_krunner_pass)
 

--- a/pass.cpp
+++ b/pass.cpp
@@ -28,6 +28,8 @@
 #include <QClipboard>
 #include <QDebug>
 #include <QApplication>
+#include <KGuiAddons/ksystemclipboard.h>
+#include <QMimeData>
 
 #include <cstdlib>
 
@@ -185,10 +187,13 @@ void Pass::match(Plasma::RunnerContext &context)
 
 void Pass::clip(const QString &msg)
 {
-    QClipboard *cb = QApplication::clipboard();
-    cb->setText(msg);
-    QTimer::singleShot(timeout * 1000, cb, [cb]() {
-        cb->setText(QString());
+    auto* mimeData = new QMimeData();
+    mimeData->setText(msg);
+    KSystemClipboard::instance()->setMimeData(mimeData, QClipboard::Clipboard);
+    QTimer::singleShot(timeout * 1000, nullptr, []() {
+        auto* mimeData = new QMimeData();
+        mimeData->setText("");
+        KSystemClipboard::instance()->setMimeData(mimeData, QClipboard::Clipboard);
     });
 }
 


### PR DESCRIPTION
Currently, `krunner-pass` does not copy text to clipboard under Wayland. This patch uses `KSystemClipboard` in order to allow copying under either X11 or Wayland.